### PR TITLE
Add rudimentary sticker support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp==1.0.5
 aiotg==0.7.11
 beautifulsoup4==4.5.1
 sqlalchemy==1.1.3
+Pillow==4.0.0


### PR DESCRIPTION
Does not reuse already-uploaded stickers (though that should not be hard to implement). This just takes the sticker from Telegram, converts it from WebP to PNG (because Riot does not play well with WebP images for some reason), and sends it to Matrix as a normal image.