### PR TITLE
Allow custom homeserver port

### DIFF
--- a/telematrix/__init__.py
+++ b/telematrix/__init__.py
@@ -184,7 +184,7 @@ async def matrix_transaction(request):
             for alias in aliases:
                 print(alias)
                 if alias.split('_')[0] != '#telegram' \
-                        or alias.split(':')[-1] != MATRIX_HOST_BARE:
+                        or not alias.endswith(MATRIX_HOST_BARE):
                     continue
 
                 tg_id = alias.split('_')[1].split(':')[0]


### PR DESCRIPTION
This commit should allow the Matrix homeserver to run on any port. Instead of splitting by : and getting the last index, it just checks the end against `MATRIX_HOST_BARE`.

For example, if the server is `'matrix.example.com:8448'.split(':')` is `8448` and the comparison always fails. 